### PR TITLE
Fix crash on Inspector View context menu

### DIFF
--- a/SafariStand/modules/STSContextMenuModule.m
+++ b/SafariStand/modules/STSContextMenuModule.m
@@ -24,6 +24,10 @@
 
 - (void)injectToContextMenuWithButtonCell:(NSMenu *)menu withVKView:(id)wkview
 {
+    if (![[wkview className] isEqualToString:@"BrowserWKView"]) {
+        return;
+    }
+
     NSMenuItem* itm;
     
     BOOL hasSelectedLink=NO;


### PR DESCRIPTION
Stand crashed Safari when I tried to open context menu on literally anything at Web Inspector.